### PR TITLE
Create tmp file before attemping to use it

### DIFF
--- a/tools/nodeux-article-writer/executor.js
+++ b/tools/nodeux-article-writer/executor.js
@@ -6,8 +6,8 @@ const articles = [
 
 console.log('Nodeux Blog Engine ...');
 
-for (let a of articles) {
-    process.stdout.write('Compiling ' + a + ' ...');
+for (const a of articles) {
+    process.stdout.write(`Compiling ${a} ...`);
     require(path.join(__dirname, 'articles', a)).execute();
     process.stdout.write(' done.\n');
 }

--- a/tools/nodeux-article-writer/helpers/article-writer.js
+++ b/tools/nodeux-article-writer/helpers/article-writer.js
@@ -1,13 +1,22 @@
 const
     fs = require('fs'),
-    path = require('path');
+    path = require('path'),
+    tmpPath = path.join(__dirname, '../../../tmp');
 
 function createArticle(params) {
     return {
-        "publishTemp": () => {
-            fs.writeFileSync(path.join(__dirname, '../../../tmp', params.main.id + '.json'), JSON.stringify(params.main), 'utf8');
+        publishTemp: () => {
+            try {
+                fs.mkdirSync(tmpPath);
+            } catch (e) {
+                if (e.code !== 'EEXIST') {
+                    throw e;
+                }
+            }
+
+            fs.writeFileSync(path.join(tmpPath, `${params.main.id}.json`), JSON.stringify(params.main), 'utf8');
         },
-        "publish": () => {
+        publish: () => {
             let articlesJSONPath = path.join(__dirname, '../../../db/articles.json');
             let articlesJSON = JSON.parse(fs.readFileSync(articlesJSONPath, 'utf8'));
             let article_updated = false;


### PR DESCRIPTION
When using the toolbelt for the article writer for the first time, tmp folder doesn't exists and throws an error.
This PR will create the tmp file before attemping to use it.